### PR TITLE
Create APPROX_COUNT_DISTINCT.md

### DIFF
--- a/T-Sql/APPROX_COUNT_DISTINCT.md
+++ b/T-Sql/APPROX_COUNT_DISTINCT.md
@@ -1,0 +1,126 @@
+To integrate HyperLogLog with Entity Framework (EF) Core or ADO.NET, follow these steps based on your database's capabilities:
+
+### **1. If Your Database Supports HyperLogLog Natively (e.g., PostgreSQL, SQL Server 2019+):**
+#### **Using SQL Server `APPROX_COUNT_DISTINCT` (for approximate counts):**
+```csharp
+// EF Core Query with Raw SQL
+var approxCount = await context.Database
+    .SqlQueryRaw<long>("SELECT APPROX_COUNT_DISTINCT(ColumnName) FROM MyTable")
+    .FirstOrDefaultAsync();
+
+// ADO.NET Example
+using (var connection = new SqlConnection(connectionString))
+{
+    await connection.OpenAsync();
+    using (var command = new SqlCommand("SELECT APPROX_COUNT_DISTINCT(ColumnName) FROM MyTable", connection))
+    {
+        var result = await command.ExecuteScalarAsync();
+        Console.WriteLine($"Approximate count: {result}");
+    }
+}
+```
+
+#### **Using PostgreSQL with `hyperloglog` Extension:**
+```csharp
+// EF Core Query with PostgreSQL-specific HyperLogLog functions
+var query = @"
+    SELECT hll_cardinality(hll_add_agg(hll_hash_text(ColumnName)))
+    FROM MyTable";
+
+var estimate = await context.Database.SqlQueryRaw<long>(query).FirstOrDefaultAsync();
+```
+
+---
+
+### **2. If Implementing HyperLogLog in Application Layer (No Native DB Support):**
+#### **Step 1: Add a HyperLogLog Library**
+Use a C# HyperLogLog implementation like [`HyperLogLog.Net`](https://www.nuget.org/packages/HyperLogLog.Net/) (NuGet package) or implement your own.
+
+#### **Step 2: Define the Entity Model**
+Store HyperLogLog registers as a `byte[]` in the database:
+```csharp
+public class HyperLogLogEntity
+{
+    public int Id { get; set; }
+    public byte[] Registers { get; set; } // Stores HyperLogLog state
+}
+```
+
+#### **Step 3: Serialize/Deserialize HyperLogLog State**
+```csharp
+// Example using HyperLogLog.Net
+public byte[] SerializeHyperLogLog(HyperLogLog hll)
+{
+    using (var stream = new MemoryStream())
+    {
+        hll.Serialize(stream);
+        return stream.ToArray();
+    }
+}
+
+public HyperLogLog DeserializeHyperLogLog(byte[] data)
+{
+    using (var stream = new MemoryStream(data))
+    {
+        return HyperLogLog.Deserialize(stream);
+    }
+}
+```
+
+#### **Step 4: Add/Update Entities with EF Core**
+```csharp
+using (var context = new AppDbContext())
+{
+    var entity = await context.HyperLogLogEntities.FindAsync(1);
+    var hll = entity == null 
+        ? new HyperLogLog(precision: 14) 
+        : DeserializeHyperLogLog(entity.Registers);
+
+    hll.LogItem("new-item-id"); // Add item
+
+    if (entity == null)
+    {
+        context.HyperLogLogEntities.Add(new HyperLogLogEntity 
+        { 
+            Registers = SerializeHyperLogLog(hll) 
+        });
+    }
+    else
+    {
+        entity.Registers = SerializeHyperLogLog(hll);
+    }
+
+    await context.SaveChangesAsync();
+}
+```
+
+#### **Step 5: Estimate Cardinality**
+```csharp
+var entity = await context.HyperLogLogEntities.FindAsync(1);
+var hll = DeserializeHyperLogLog(entity.Registers);
+var estimate = hll.Count();
+Console.WriteLine($"Estimated unique items: {estimate}");
+```
+
+---
+
+### **Key Considerations**
+- **Concurrency:** Use database locks (e.g., `SELECT FOR UPDATE` in SQL) or optimistic concurrency to handle concurrent updates.
+- **Performance:** Serializing/deserializing large HyperLogLog structures may impact performance.
+- **Precision:** Adjust the `precision` parameter to balance accuracy and memory usage (typical range: 10–18).
+
+### **Alternative: Use Redis with HyperLogLog**
+If using Redis, leverage `StackExchange.Redis`:
+```csharp
+var redis = ConnectionMultiplexer.Connect("localhost");
+var db = redis.GetDatabase();
+db.HyperLogLogAdd("my-hll-key", "item1");
+var estimate = db.HyperLogLogLength("my-hll-key");
+```
+
+---
+
+### **Summary**
+- **Native DB Support:** Use `APPROX_COUNT_DISTINCT` (SQL Server) or PostgreSQL `hyperloglog` extension with raw SQL via EF Core/ADO.NET.
+- **Custom Implementation:** Store HyperLogLog state as a `byte[]` and serialize/deserialize using EF Core or ADO.NET.
+- **Redis:** Opt for Redis if approximate counting is a critical requirement.


### PR DESCRIPTION
```markdown
To integrate HyperLogLog with Entity Framework (EF) Core or ADO.NET, follow these steps based on your database's capabilities:

### **1. If Your Database Supports HyperLogLog Natively (e.g., PostgreSQL, SQL Server 2019+):**
#### **Using SQL Server `APPROX_COUNT_DISTINCT` (for approximate counts):**
```csharp
// EF Core Query with Raw SQL
var approxCount = await context.Database
    .SqlQueryRaw<long>("SELECT APPROX_COUNT_DISTINCT(ColumnName) FROM MyTable")
    .FirstOrDefaultAsync();

// ADO.NET Example
using (var connection = new SqlConnection(connectionString)) {
    await connection.OpenAsync();
    using (var command = new SqlCommand("SELECT APPROX_COUNT_DISTINCT(ColumnName) FROM MyTable", connection))
    {
        var result = await command.ExecuteScalarAsync();
        Console.WriteLine($"Approximate count: {result}");
    }
}
```

#### **Using PostgreSQL with `hyperloglog` Extension:**
```csharp
// EF Core Query with PostgreSQL-specific HyperLogLog functions var query = @"
    SELECT hll_cardinality(hll_add_agg(hll_hash_text(ColumnName)))
    FROM MyTable";

var estimate = await context.Database.SqlQueryRaw<long>(query).FirstOrDefaultAsync();
```

---

### **2. If Implementing HyperLogLog in Application Layer (No Native DB Support):**
#### **Step 1: Add a HyperLogLog Library**
Use a C# HyperLogLog implementation like [`HyperLogLog.Net`](https://www.nuget.org/packages/HyperLogLog.Net/) (NuGet package) or implement your own.

#### **Step 2: Define the Entity Model**
Store HyperLogLog registers as a `byte[]` in the database:
```csharp
public class HyperLogLogEntity
{
    public int Id { get; set; }
    public byte[] Registers { get; set; } // Stores HyperLogLog state
}
```

#### **Step 3: Serialize/Deserialize HyperLogLog State**
```csharp
// Example using HyperLogLog.Net
public byte[] SerializeHyperLogLog(HyperLogLog hll) {
    using (var stream = new MemoryStream())
    {
        hll.Serialize(stream);
        return stream.ToArray();
    }
}

public HyperLogLog DeserializeHyperLogLog(byte[] data) {
    using (var stream = new MemoryStream(data))
    {
        return HyperLogLog.Deserialize(stream);
    }
}
```

#### **Step 4: Add/Update Entities with EF Core**
```csharp
using (var context = new AppDbContext())
{
    var entity = await context.HyperLogLogEntities.FindAsync(1);
    var hll = entity == null 
        ? new HyperLogLog(precision: 14) 
        : DeserializeHyperLogLog(entity.Registers);

    hll.LogItem("new-item-id"); // Add item

    if (entity == null)
    {
        context.HyperLogLogEntities.Add(new HyperLogLogEntity 
        { 
            Registers = SerializeHyperLogLog(hll) 
        });
    }
    else
    {
        entity.Registers = SerializeHyperLogLog(hll);
    }

    await context.SaveChangesAsync();
}
```

#### **Step 5: Estimate Cardinality**
```csharp
var entity = await context.HyperLogLogEntities.FindAsync(1); var hll = DeserializeHyperLogLog(entity.Registers); var estimate = hll.Count();
Console.WriteLine($"Estimated unique items: {estimate}");
```

---

### **Key Considerations**
- **Concurrency:** Use database locks (e.g., `SELECT FOR UPDATE` in SQL) or optimistic concurrency to handle concurrent updates.
- **Performance:** Serializing/deserializing large HyperLogLog structures may impact performance.
- **Precision:** Adjust the `precision` parameter to balance accuracy and memory usage (typical range: 10–18).

### **Alternative: Use Redis with HyperLogLog**
If using Redis, leverage `StackExchange.Redis`:
```csharp
var redis = ConnectionMultiplexer.Connect("localhost"); var db = redis.GetDatabase();
db.HyperLogLogAdd("my-hll-key", "item1");
var estimate = db.HyperLogLogLength("my-hll-key");
```

---

### **Summary**
- **Native DB Support:** Use `APPROX_COUNT_DISTINCT` (SQL Server) or PostgreSQL `hyperloglog` extension with raw SQL via EF Core/ADO.NET.
- **Custom Implementation:** Store HyperLogLog state as a `byte[]` and serialize/deserialize using EF Core or ADO.NET.
- **Redis:** Opt for Redis if approximate counting is a critical requirement.
```